### PR TITLE
V0.5 event handler

### DIFF
--- a/editor/finder.js
+++ b/editor/finder.js
@@ -199,21 +199,16 @@ new State({
     id: Finder.state,
 
     keybinds: {
-
-        escape: () => nodeFinder.hide(),
-
-        other: event => nodeFinder.search(event.target.value)
-
+		'escape': () => nodeFinder.hide(),
+        'alphabet': event => nodeFinder.search(event.target.value),
     },
 
     mousebinds: {
-
-        left: {
-
-            finder: () => nodeFinder.hide()
-
+        all: {
+			not: {
+				'.search-container': () => nodeFinder.hide()
+			}
         }
-
     }
 
 });

--- a/editor/keys.js
+++ b/editor/keys.js
@@ -42,7 +42,7 @@ Key.list = {
 	60: "<",
 	61: "equals (firefox)",
 	64: "@ (firefox)",
-	/*65: "a",
+	65: "a",
 	66: "b",
 	67: "c",
 	68: "d",
@@ -67,7 +67,7 @@ Key.list = {
 	87: "w",
 	88: "x",
 	89: "y",
-	90: "z",*/
+	90: "z",
 	91: "Windows Key / Left ⌘ / Chromebook Search key",
 	92: "right window key ",
 	93: "Windows Menu / Right ⌘",

--- a/editor/states.js
+++ b/editor/states.js
@@ -24,34 +24,34 @@ new State({
 
         left: {
 
-            'node-container': (event) => {
+            '.node-container': ({ target }) => {
 
-                new Selection(Node.all[ event.target.id ]);
+				new Selection(Node.all[ target.id ]);
+	
+			},
 
-            },
+			'.header': ({ target }) => {
 
-            header: () => {
-
-                const nodeObject = Node.all[ event.target.ref ]; // $nodes
-                new Draggable({
+                const nodeInstance = Node.all[ target.parentElement.id ];
+				
+				new Draggable({
                     event,
                     type: 'drag',
-                    element: nodeObject.element.node,
-					object: nodeObject,
-					bounderyClamp: nodeObject.draggableBoundaryClamp.bind(nodeObject),						/* finitepane-rollback */
-                    callback:  nodeObject.update.bind(nodeObject)
+                    element: nodeInstance.element.node,
+					object: nodeInstance,
+					bounderyClamp: nodeInstance.draggableBoundaryClamp.bind(nodeInstance),						
+                    callback: nodeInstance.update.bind(nodeInstance)
                 });
 
             },
 
-            'snap-dock': () => {
+            '.snap-dock': ({ target }) => {
 
-				const dockObject = Dock.all[ event.target.ref ];
-                new Linkable(event, dockObject);
+                new Linkable(event, Dock.all[ target.ref ]);
 
             },
 
-            varInput: function(event) {
+            '.varInput': function(event) {
 
                 this.input = event.target;
                 this.dock = Dock.all[ this.input.ref ];
@@ -60,7 +60,7 @@ new State({
 
                 State.change(Editor.state.input, this);
 
-            },
+			}
 
         }
 
@@ -97,21 +97,11 @@ new State({
     },
 
     mousebinds: {
-
         all: {
-
             not: {
-
-                varInput: () => {
-
-                    State.change(Editor.state.default);
-
-                }
-
+                '.varInput': () => State.change(Editor.state.default)
             }
-
         }
-
     }
 
 });


### PR DESCRIPTION
Revisited the State system to get rid of the `pointer-event` CSS property. The new event handler for mouse clicks works by using the `matches` methods and bubbling up to the `document` object. In addition, the `keyEvent` class had a new feature added: we can now use the `"alphabet"` selector as a keybind to catch any alphabetic character.